### PR TITLE
feat: add reranking support

### DIFF
--- a/api/k8s/v1/model_types.go
+++ b/api/k8s/v1/model_types.go
@@ -142,12 +142,13 @@ type ModelSpec struct {
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=TextGeneration;TextEmbedding;SpeechToText
+// +kubebuilder:validation:Enum=TextGeneration;TextEmbedding;Reranking;SpeechToText
 type ModelFeature string
 
 const (
 	ModelFeatureTextGeneration = "TextGeneration"
 	ModelFeatureTextEmbedding  = "TextEmbedding"
+	ModelFeatureReranking      = "Reranking"
 	// TODO (samos123): Add validation that Speech to Text only supports Faster Whisper.
 	ModelFeatureSpeechToText = "SpeechToText"
 )

--- a/api/openai/v1/rerank.go
+++ b/api/openai/v1/rerank.go
@@ -1,0 +1,38 @@
+package v1
+
+import (
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// RerankRequest represents a request to rerank a list of documents based on a query.
+type RerankRequest struct {
+	Query     string   `json:"query"`
+	Documents []string `json:"documents"`
+	Model     string   `json:"model"`
+	TopN      int      `json:"top_n,omitzero"`
+
+	// Unknown fields should be preserved to fully support engines that accept
+	// extended parameters.
+	Unknown jsontext.Value `json:",unknown"`
+}
+
+func (r *RerankRequest) GetModel() string  { return r.Model }
+func (r *RerankRequest) SetModel(m string) { r.Model = m }
+
+// RerankResult contains a single reranked document and its relevance score.
+type RerankResult struct {
+	DocumentIndex  int     `json:"document_index"`
+	Document       string  `json:"document,omitzero"`
+	RelevanceScore float32 `json:"relevance_score"`
+}
+
+// RerankResponse represents the response from a reranking request.
+type RerankResponse struct {
+	Object string         `json:"object"`
+	Data   []RerankResult `json:"data"`
+	Model  string         `json:"model"`
+
+	// Unknown fields should be preserved to fully support engines that return
+	// extended parameters.
+	Unknown jsontext.Value `json:",unknown"`
+}

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -148,6 +148,7 @@ spec:
                   enum:
                   - TextGeneration
                   - TextEmbedding
+                  - Reranking
                   - SpeechToText
                   type: string
                 type: array

--- a/charts/models/values.yaml
+++ b/charts/models/values.yaml
@@ -589,6 +589,12 @@ catalog:
     url: "hf://BAAI/bge-small-en-v1.5"
     engine: Infinity
     resourceProfile: cpu:1
+  bge-rerank-base-cpu:
+    enabled: false
+    features: ["Reranking"]
+    url: "hf://BAAI/bge-reranker-base"
+    engine: Infinity
+    resourceProfile: cpu:1
   # Opt #
   opt-125m-cpu:
     enabled: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,15 @@
 # KubeAI: AI Inferencing Operator
 
-Deploy and scale machine learning models on Kubernetes. Built for LLMs, embeddings, and speech-to-text.
+Deploy and scale machine learning models on Kubernetes. Built for LLMs, embeddings, reranking, and speech-to-text.
 
 ## Highlights
 
 What is it for?
 
-🚀 **LLM Inferencing** - Operate vLLM and Ollama servers  
-🎙️ **Speech Processing** - Transcribe audio with FasterWhisper  
-🔢 **Vector Embeddings** - Generate embeddings with Infinity  
+🚀 **LLM Inferencing** - Operate vLLM and Ollama servers
+🎙️ **Speech Processing** - Transcribe audio with FasterWhisper
+🔢 **Vector Embeddings** - Generate embeddings with Infinity
+📚 **Reranking** - Reorder search results with cross-encoder models
 
 What do you get?
 
@@ -54,6 +55,7 @@ No need to change your client libraries, KubeAI supports the following endpoints
 /v1/chat/completions
 /v1/completions
 /v1/embeddings
+/v1/rerank
 /v1/models
 /v1/audio/transcriptions
 ```

--- a/docs/how-to/configure-reranking-models.md
+++ b/docs/how-to/configure-reranking-models.md
@@ -1,0 +1,41 @@
+# Configure reranking models
+
+KubeAI supports reranking models via the Infinity engine.
+
+## Install BAAI/bge-reranker-base model using Infinity
+
+Create a file named `kubeai-models.yaml` with the following content:
+
+```yaml
+catalog:
+  bge-rerank-base-cpu:
+    enabled: true
+    features: ["Reranking"]
+    owner: baai
+    url: "hf://BAAI/bge-reranker-base"
+    engine: Infinity
+    resourceProfile: cpu:1
+    minReplicas: 1
+```
+
+Apply the kubeai-models helm chart:
+
+```bash
+helm install kubeai-models kubeai/models -f ./kubeai-models.yaml
+```
+
+Once the pod is ready, you can call the rerank endpoint:
+
+```python
+import requests
+resp = requests.post(
+    "http://localhost:8000/openai/v1/rerank",
+    json={
+        "model": "bge-rerank-base-cpu",
+        "query": "Which document talks about apples?",
+        "documents": ["An apple a day keeps the doctor away", "Oranges are tasty"],
+    },
+)
+print(resp.json())
+```
+

--- a/docs/installation/aks.md
+++ b/docs/installation/aks.md
@@ -137,4 +137,5 @@ Take a look at the following how-to guides to deploy models:
 
 - [Configure Text Generation Models](../how-to/configure-text-generation-models.md)
 - [Configure Embedding Models](../how-to/configure-embedding-models.md)
+- [Configure Reranking Models](../how-to/configure-reranking-models.md)
 - [Configure Speech to Text Models](../how-to/configure-speech-to-text.md)

--- a/docs/installation/any.md
+++ b/docs/installation/any.md
@@ -98,5 +98,6 @@ Take a look at the following how-to guides to deploy models:
 
 * [Configure Text Generation Models](../how-to/configure-text-generation-models.md)
 * [Configure Embedding Models](../how-to/configure-embedding-models.md)
+* [Configure Reranking Models](../how-to/configure-reranking-models.md)
 * [Configure Speech to Text Models](../how-to/configure-speech-to-text.md)
 

--- a/docs/installation/eks.md
+++ b/docs/installation/eks.md
@@ -151,4 +151,5 @@ Take a look at the following how-to guides to deploy models:
 
 * [Configure Text Generation Models](../how-to/configure-text-generation-models.md)
 * [Configure Embedding Models](../how-to/configure-embedding-models.md)
+* [Configure Reranking Models](../how-to/configure-reranking-models.md)
 * [Configure Speech to Text Models](../how-to/configure-speech-to-text.md)

--- a/docs/installation/gke.md
+++ b/docs/installation/gke.md
@@ -68,4 +68,5 @@ Take a look at the following how-to guides to deploy models:
 
 * [Configure Text Generation Models](../how-to/configure-text-generation-models.md)
 * [Configure Embedding Models](../how-to/configure-embedding-models.md)
+* [Configure Reranking Models](../how-to/configure-reranking-models.md)
 * [Configure Speech to Text Models](../how-to/configure-speech-to-text.md)

--- a/docs/reference/kubernetes-api.md
+++ b/docs/reference/kubernetes-api.md
@@ -108,7 +108,7 @@ _Underlying type:_ _string_
 
 
 _Validation:_
-- Enum: [TextGeneration TextEmbedding SpeechToText]
+- Enum: [TextGeneration TextEmbedding Reranking SpeechToText]
 
 _Appears in:_
 - [ModelSpec](#modelspec)
@@ -130,7 +130,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `url` _string_ | URL of the model to be served.<br />Currently the following formats are supported:<br /><br />For VLLM, FasterWhisper, Infinity engines:<br /><br />"hf://<repo>/<model>"<br />"pvc://<pvcName>"<br />"pvc://<pvcName>/<pvcSubpath>"<br />"gs://<bucket>/<path>" (only with cacheProfile)<br />"oss://<bucket>/<path>" (only with cacheProfile)<br />"s3://<bucket>/<path>" (only with cacheProfile)<br /><br />For OLlama engine:<br /><br />"ollama://<model>" |  | Required: \{\} <br /> |
 | `adapters` _[Adapter](#adapter) array_ |  |  |  |
-| `features` _[ModelFeature](#modelfeature) array_ | Features that the model supports.<br />Dictates the APIs that are available for the model. |  | Enum: [TextGeneration TextEmbedding SpeechToText] <br /> |
+| `features` _[ModelFeature](#modelfeature) array_ | Features that the model supports.<br />Dictates the APIs that are available for the model. |  | Enum: [TextGeneration TextEmbedding Reranking SpeechToText] <br /> |
 | `engine` _string_ | Engine to be used for the server process. |  | Enum: [OLlama VLLM FasterWhisper Infinity] <br />Required: \{\} <br /> |
 | `resourceProfile` _string_ | ResourceProfile required to serve the model.<br />Use the format "<resource-profile-name>:<count>".<br />Example: "nvidia-gpu-l4:2" - 2x NVIDIA L4 GPUs.<br />Must be a valid ResourceProfile defined in the system config. |  |  |
 | `cacheProfile` _string_ | CacheProfile to be used for caching model artifacts.<br />Must be a valid CacheProfile defined in the system config. |  |  |

--- a/docs/reference/openai-api-compatibility.md
+++ b/docs/reference/openai-api-compatibility.md
@@ -32,6 +32,14 @@ POST /v1/embeddings
 
 * Supported for  Models with `.spec.features: ["TextEmbedding"]`.
 
+### Reranking
+
+```
+POST /v1/rerank
+```
+
+* Supported for  Models with `.spec.features: ["Reranking"]`.
+
 ### Speech-to-Text
 
 ```

--- a/internal/apiutils/request.go
+++ b/internal/apiutils/request.go
@@ -172,6 +172,8 @@ func (r *Request) readJSONBody(body io.Reader, path string) error {
 		r.modelRequest = &openaiv1.ChatCompletionRequest{}
 	case "/v1/embeddings":
 		r.modelRequest = &openaiv1.EmbeddingRequest{}
+	case "/v1/rerank":
+		r.modelRequest = &openaiv1.RerankRequest{}
 	default:
 		return fmt.Errorf("unknown path: %q", path)
 	}

--- a/internal/apiutils/request_test.go
+++ b/internal/apiutils/request_test.go
@@ -59,6 +59,12 @@ func TestParseRequest(t *testing.T) {
 			expModel:  "test-model",
 			expPrefix: "test-prefi", // "test-prefix" (max 10) --> "test-prefi"
 		},
+		{
+			name:     "rerank request",
+			body:     `{"model": "test-model", "query": "q", "documents": ["d1", "d2"]}`,
+			path:     "/v1/rerank",
+			expModel: "test-model",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/openaiserver/handler.go
+++ b/internal/openaiserver/handler.go
@@ -38,6 +38,7 @@ func NewHandler(k8sClient client.Client, modelProxy *modelproxy.Handler) *Handle
 	handle("/openai/v1/chat/completions", http.StripPrefix("/openai", modelProxy))
 	handle("/openai/v1/completions", http.StripPrefix("/openai", modelProxy))
 	handle("/openai/v1/embeddings", http.StripPrefix("/openai", modelProxy))
+	handle("/openai/v1/rerank", http.StripPrefix("/openai", modelProxy))
 	handle("/openai/v1/audio/transcriptions", http.StripPrefix("/openai", modelProxy))
 	handle("/openai/v1/models", http.HandlerFunc(h.getModels))
 

--- a/manifests/models/bge-rerank-base-cpu.yaml
+++ b/manifests/models/bge-rerank-base-cpu.yaml
@@ -1,0 +1,11 @@
+# Source: models/templates/models.yaml
+apiVersion: kubeai.org/v1
+kind: Model
+metadata:
+  name: bge-rerank-base-cpu
+spec:
+  features: [Reranking]
+  url: hf://BAAI/bge-reranker-base
+  engine: Infinity
+  minReplicas: 0
+  resourceProfile: cpu:1


### PR DESCRIPTION
## Summary
- add Reranking model feature and endpoint
- support rerank request parsing and proxying
- document reranking usage and provide example model

## Testing
- `go test ./... | tail -n 20` *(fails: unable to start control plane: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b1749835c832eb5e736622b080441