### PR TITLE
Update repository references to kubeai-project org

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -6,7 +6,7 @@ domain: substratus.ai
 layout:
 - go.kubebuilder.io/v4
 projectName: kubeai
-repo: github.com/substratusai/kubeai
+repo: github.com/kubeai-project/kubeai
 resources:
 - api:
     crdVersion: v1
@@ -15,6 +15,6 @@ resources:
   domain: substratus.ai
   group: kubeai
   kind: Model
-  path: github.com/substratusai/kubeai/api/k8s/v1
+  path: github.com/kubeai-project/kubeai/api/k8s/v1
   version: v1
 version: "3"

--- a/api/openai/v1/chat_completions_test.go
+++ b/api/openai/v1/chat_completions_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-json-experiment/json"
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/openai/v1"
+	v1 "github.com/kubeai-project/kubeai/api/openai/v1"
 )
 
 func TestChatCompletionRequestPrefix(t *testing.T) {

--- a/api/openai/v1/completions_test.go
+++ b/api/openai/v1/completions_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-json-experiment/json"
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/openai/v1"
+	v1 "github.com/kubeai-project/kubeai/api/openai/v1"
 )
 
 func TestCompletionRequestPrefix(t *testing.T) {

--- a/api/openai/v1/embeddings_test.go
+++ b/api/openai/v1/embeddings_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-json-experiment/json"
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/openai/v1"
+	v1 "github.com/kubeai-project/kubeai/api/openai/v1"
 )
 
 func TestEmbeddingRequest_JSON(t *testing.T) {

--- a/charts/kubeai/templates/huggingface-secret.yaml
+++ b/charts/kubeai/templates/huggingface-secret.yaml
@@ -1,5 +1,5 @@
 # Only create the secret if the token is not empty.
-# See: https://github.com/substratusai/kubeai/issues/232
+# See: https://github.com/kubeai-project/kubeai/issues/232
 {{- if and .Values.secrets.huggingface.create (not (empty .Values.secrets.huggingface.token)) }}
 apiVersion: v1
 kind: Secret

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"os"
 
-	"github.com/substratusai/kubeai/internal/manager"
+	"github.com/kubeai-project/kubeai/internal/manager"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ KubeAI consists of two primary sub-components:
 
 **2. The model operator:** the KubeAI model operator manages backend server Pods directly. It automates common operations such as downloading models, mounting volumes, and loading dynamic LoRA adapters via the KubeAI Model CRD.
 
-Both of these components are co-located in the same deployment, but [could be deployed independently](https://github.com/substratusai/kubeai/issues/430).
+Both of these components are co-located in the same deployment, but [could be deployed independently](https://github.com/kubeai-project/kubeai/issues/430).
 
 <img src="./diagrams/arch.excalidraw.png"></img>
 

--- a/docs/blog/posts/llm-load-balancing-at-scale-chwbl.md
+++ b/docs/blog/posts/llm-load-balancing-at-scale-chwbl.md
@@ -61,7 +61,7 @@ The CHWBL algorithm extends traditional consistent hashing by incorporating load
 
 ## 5. Implementation
 
-We integrated the CHWBL routing strategy into the <a href="https://github.com/substratusai/kubeai" target="_blank">KubeAI project</a> under the PrefixHash configuration. This strategy functions as follows:
+We integrated the CHWBL routing strategy into the <a href="https://github.com/kubeai-project/kubeai" target="_blank">KubeAI project</a> under the PrefixHash configuration. This strategy functions as follows:
 
 1. **Request Inspection:** The incoming HTTP body is analyzed (OpenAI-formatted API request).
 2. **Prefix Extraction:** A prefix is extracted from the request (for example, using the first user message in chat completions) as well as the requested LoRA adapter (if applicable).

--- a/docs/concepts/storage-caching.md
+++ b/docs/concepts/storage-caching.md
@@ -35,6 +35,6 @@ KubeAI can manage model caches on a shared filesystem (i.e. AWS [EFS](https://aw
 
 ## C. Model on read-only-many disk
 
-**Status:** [Planned](https://github.com/substratusai/kubeai/blob/main/proposals/model-storage.md).
+**Status:** [Planned](https://github.com/kubeai-project/kubeai/blob/main/proposals/model-storage.md).
 
 Examples: [GCP Hyperdisk ML](https://cloud.google.com/compute/docs/disks/hyperdisks)

--- a/docs/how-to/build-models-into-containers.md
+++ b/docs/how-to/build-models-into-containers.md
@@ -13,7 +13,7 @@ export IMAGE=us-central1-docker.pkg.dev/substratus-dev/default/ollama-builtin-qw
 Build and push image. Note: building (downloading base image & model) and pushing (uploading image & model) can take a while depending on the size of the model.
 
 ```bash
-git clone https://github.com/substratusai/kubeai
+git clone https://github.com/kubeai-project/kubeai
 cd ./kubeai/examples/ollama-builtin
 
 docker build --build-arg MODEL_URL=$MODEL_URL -t $IMAGE .

--- a/docs/how-to/cache-models-with-aws-efs.md
+++ b/docs/how-to/cache-models-with-aws-efs.md
@@ -118,7 +118,7 @@ Make sure to set `file_system_id` match the EFS file system ID created in the fi
 
 ## 3. Configure KubeAI with the EFS cache profile
 
-You can skip this step if you've already installed KubeAI using the [EKS Helm values file: values-eks.yaml](https://github.com/substratusai/kubeai/blob/main/charts/kubeai/values-eks.yaml).
+You can skip this step if you've already installed KubeAI using the [EKS Helm values file: values-eks.yaml](https://github.com/kubeai-project/kubeai/blob/main/charts/kubeai/values-eks.yaml).
 
 Configure KubeAI with the `efs-dynamic` cache profile.
 ```bash

--- a/docs/how-to/cache-models-with-gcp-filestore.md
+++ b/docs/how-to/cache-models-with-gcp-filestore.md
@@ -15,7 +15,7 @@ gcloud services enable file.googleapis.com
 
 ## 1. Configure KubeAI with Caching Profile
 
-You can skip this step if you've already installed KubeAI using the [GKE Helm values file: values-gke.yaml](https://github.com/substratusai/kubeai/blob/main/charts/kubeai/values-gke.yaml).
+You can skip this step if you've already installed KubeAI using the [GKE Helm values file: values-gke.yaml](https://github.com/kubeai-project/kubeai/blob/main/charts/kubeai/values-gke.yaml).
 
 Configure KubeAI with the Filestore cache profiles.
 ```bash
@@ -32,7 +32,7 @@ EOF
 ```
 
 ## 2. Deploy a model that uses the Filestore Caching Profile
-Apply a Model with the cache profile set to `standard-filestore` (defined in the reference [GKE Helm values file](https://github.com/substratusai/kubeai/blob/main/charts/kubeai/values-gke.yaml)).
+Apply a Model with the cache profile set to `standard-filestore` (defined in the reference [GKE Helm values file](https://github.com/kubeai-project/kubeai/blob/main/charts/kubeai/values-gke.yaml)).
 
 <details markdown="1">
 <summary>TIP: If you want to use `premium-filestore` you will need to ensure you have quota.</summary>

--- a/docs/how-to/configure-resource-profiles.md
+++ b/docs/how-to/configure-resource-profiles.md
@@ -4,7 +4,7 @@ This guide will cover modifying preconfigured [resource profiles](../concepts/re
 
 ## Modifying preconfigured resource profiles
 
-The KubeAI helm chart comes with preconfigured resource profiles for common resource types such as NVIDIA L4 GPUs. You can view these profiles in the [default helm values file](https://github.com/substratusai/kubeai/blob/main/charts/kubeai/values.yaml).
+The KubeAI helm chart comes with preconfigured resource profiles for common resource types such as NVIDIA L4 GPUs. You can view these profiles in the [default helm values file](https://github.com/kubeai-project/kubeai/blob/main/charts/kubeai/values.yaml).
 
 These profiles usually require some additional settings based on the cluster/cloud that KubeAI is installed into. You can modify a resource profile by setting custom helm values and runing `helm install` or `helm upgrade`. For example, if you are installing KubeAI on GKE you will need to set GKE-specific node selectors:
 

--- a/docs/how-to/configure-text-generation-models.md
+++ b/docs/how-to/configure-text-generation-models.md
@@ -4,22 +4,22 @@ KubeAI supports the following engines for text generation models (LLMs, VLMs, ..
 
 - vLLM (Recommended for GPU)
 - Ollama (Recommended for CPU)
-- Need something else? Please file an issue on [GitHub](https://github.com/substratusai/kubeai).
+- Need something else? Please file an issue on [GitHub](https://github.com/kubeai-project/kubeai).
 
 There are 2 ways to install a text generation model in KubeAI:
 - Use Helm with the `kubeai/models` chart.
 - Use `kubectl apply -f model.yaml` to install a Model Custom Resource.
 
 KubeAI comes with pre-validated and optimized Model configurations for popular text generation models. These models are available in the
-[kubeai/models Helm chart](https://github.com/substratusai/kubeai/tree/main/charts/models)
+[kubeai/models Helm chart](https://github.com/kubeai-project/kubeai/tree/main/charts/models)
 and are also published as raw manifests in the
-[manifests/model directory](https://github.com/substratusai/kubeai/tree/main/manifests/models).
+[manifests/model directory](https://github.com/kubeai-project/kubeai/tree/main/manifests/models).
 
 You can also easily define your own models using the Model Custom Resource directly or by using the `kubeai/models` Helm chart.
 
 ## Install a Text Generation Model using Helm
 
-You can take a look at all the pre-configured models in the chart's [default values file](https://github.com/substratusai/kubeai/blob/main/charts/models/values.yaml).
+You can take a look at all the pre-configured models in the chart's [default values file](https://github.com/kubeai-project/kubeai/blob/main/charts/models/values.yaml).
 
 You can get the default values for the models chart using the following command:
 ```bash

--- a/docs/how-to/install-models.md
+++ b/docs/how-to/install-models.md
@@ -4,11 +4,11 @@ This guide provides instructions on how to configure KubeAI models.
 
 ## Installing models with helm
 
-KubeAI provides a [chart](https://github.com/substratusai/kubeai/blob/main/charts/models) that contains preconfigured models.
+KubeAI provides a [chart](https://github.com/kubeai-project/kubeai/blob/main/charts/models) that contains preconfigured models.
 
 ### Preconfigured models with helm
 
-When you are defining Helm values for the `kubeai/models` chart you can install a preconfigured Model by setting `enabled: true`. You can view a list of all preconfigured models in the chart's [default values file](https://github.com/substratusai/kubeai/blob/main/charts/models/values.yaml). 
+When you are defining Helm values for the `kubeai/models` chart you can install a preconfigured Model by setting `enabled: true`. You can view a list of all preconfigured models in the chart's [default values file](https://github.com/kubeai-project/kubeai/blob/main/charts/models/values.yaml). 
 
 ```yaml
 # helm-values.yaml
@@ -56,7 +56,7 @@ kubectl explain models.spec
 kubectl explain models.spec.engine
 ```
 
-You can view all example manifests on the [GitHub repository](https://github.com/substratusai/kubeai/tree/main/manifests/models).
+You can view all example manifests on the [GitHub repository](https://github.com/kubeai-project/kubeai/tree/main/manifests/models).
 
 Below are few examples using various engines and resource profiles.
 
@@ -96,7 +96,7 @@ spec:
 
 ## Programmatically installing models
 
-See the [examples](https://github.com/substratusai/kubeai/tree/main/examples/k8s-api-clients).
+See the [examples](https://github.com/kubeai-project/kubeai/tree/main/examples/k8s-api-clients).
 
 ## Calling a model
 
@@ -164,4 +164,4 @@ When the cluster is under resource pressure, Kubernetes will evict lower-priorit
 
 ## Feedback welcome: A model management UI
 
-We are considering adding a UI for managing models in a running KubeAI instance. Give the [GitHub Issue](https://github.com/substratusai/kubeai/issues/148) a thumbs up if you would be interested in this feature.
+We are considering adding a UI for managing models in a running KubeAI instance. Give the [GitHub Issue](https://github.com/kubeai-project/kubeai/issues/148) a thumbs up if you would be interested in this feature.

--- a/docs/how-to/load-models-from-pvc.md
+++ b/docs/how-to/load-models-from-pvc.md
@@ -36,8 +36,8 @@ Ollama requires using ReadWriteMany access mode because the rename operation `ol
 
 ### Example: Loading Qwen 0.5b from PVC
 
-1. Create a PVC with ReadWriteMany named `model-pvc`. See [example](https://github.com/substratusai/kubeai/blob/main/examples/ollama-pvc/pvc.yaml).
-2. Create a K8s Job to load the model onto `model-pvc. See [example](https://github.com/substratusai/kubeai/blob/main/examples/ollama-pvc/job.yaml)
+1. Create a PVC with ReadWriteMany named `model-pvc`. See [example](https://github.com/kubeai-project/kubeai/blob/main/examples/ollama-pvc/pvc.yaml).
+2. Create a K8s Job to load the model onto `model-pvc. See [example](https://github.com/kubeai-project/kubeai/blob/main/examples/ollama-pvc/job.yaml)
 
     The PVC should now have a `blobs/` and `manifests/` directory after the loader completes.
 

--- a/docs/how-to/observability-with-prometheus-stack.md
+++ b/docs/how-to/observability-with-prometheus-stack.md
@@ -39,7 +39,7 @@ metrics:
       labels: {}
 ```
 
-If you want to manually create the PodMonitor please take a look at the KubeAI helm chart [vLLM PodMonitor template](https://github.com/substratusai/kubeai/blob/main/charts/kubeai/templates/vllm-pod-monitor.yaml).
+If you want to manually create the PodMonitor please take a look at the KubeAI helm chart [vLLM PodMonitor template](https://github.com/kubeai-project/kubeai/blob/main/charts/kubeai/templates/vllm-pod-monitor.yaml).
 
 
 
@@ -64,4 +64,4 @@ You can get the credential if that doesn't work:
 kubectl get secret prometheus-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
 ```
 
-You can import the example vLLM dashboard in the KubeAI repo at [examples/observability/vllm-grafana-dashboard.json](https://github.com/substratusai/kubeai/blob/main/examples/observability/vllm-grafana-dashboard.json).
+You can import the example vLLM dashboard in the KubeAI repo at [examples/observability/vllm-grafana-dashboard.json](https://github.com/kubeai-project/kubeai/blob/main/examples/observability/vllm-grafana-dashboard.json).

--- a/docs/how-to/serve-lora-adapters.md
+++ b/docs/how-to/serve-lora-adapters.md
@@ -32,7 +32,7 @@ You can install this Model using kubectl:
 kubectl apply -f ./model.yaml
 ```
 
-Or if you are managed models with the KubeAI [models helm chart](https://github.com/substratusai/kubeai/tree/main/charts/models) you can add adapters to a given model via your helm values:
+Or if you are managed models with the KubeAI [models helm chart](https://github.com/kubeai-project/kubeai/tree/main/charts/models) you can add adapters to a given model via your helm values:
 
 ```yaml
 # helm-values.yaml

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -32,7 +32,7 @@ entries:
     name: kubeai
     type: application
     urls:
-    - https://github.com/substratusai/kubeai/releases/download/kubeai-helm-chart-0.2.1/kubeai-0.2.1.tgz
+    - https://github.com/kubeai-project/kubeai/releases/download/kubeai-helm-chart-0.2.1/kubeai-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v2
     appVersion: v0.4.0
@@ -65,7 +65,7 @@ entries:
     name: kubeai
     type: application
     urls:
-    - https://github.com/substratusai/kubeai/releases/download/kubeai-helm-chart-0.2.0/kubeai-0.2.0.tgz
+    - https://github.com/kubeai-project/kubeai/releases/download/kubeai-helm-chart-0.2.0/kubeai-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v2
     appVersion: v0.4.0
@@ -98,6 +98,6 @@ entries:
     name: kubeai
     type: application
     urls:
-    - https://github.com/substratusai/kubeai/releases/download/kubeai-0.1.3/kubeai-0.1.3.tgz
+    - https://github.com/kubeai-project/kubeai/releases/download/kubeai-0.1.3/kubeai-0.1.3.tgz
     version: 0.1.3
 generated: "2024-08-31T01:58:59.660091449Z"

--- a/docs/installation/aks.md
+++ b/docs/installation/aks.md
@@ -127,7 +127,7 @@ helm upgrade --install kubeai kubeai/kubeai \
 
 ### Resource Profiles
 
-For AKS GPU deployments using the upstream Kubernetes device plugin, you can customize resource requests and limits via KubeAI’s [values-nvidia-k8s-device-plugin.yaml](https://github.com/substratusai/kubeai/blob/main/charts/kubeai/values-nvidia-k8s-device-plugin.yaml).
+For AKS GPU deployments using the upstream Kubernetes device plugin, you can customize resource requests and limits via KubeAI’s [values-nvidia-k8s-device-plugin.yaml](https://github.com/kubeai-project/kubeai/blob/main/charts/kubeai/values-nvidia-k8s-device-plugin.yaml).
 
 We recommend referencing [the installation guide](../any/#installation-using-nvidia-gpus) for examples of how to specify these resource profiles within your Helm values. This file contains preconfigured resource profiles you can adjust for your environment.
 

--- a/docs/tutorials/langchain.md
+++ b/docs/tutorials/langchain.md
@@ -1,7 +1,7 @@
 # Using LangChain with KubeAI
 
 LangChain makes it easy to build applications powered by LLMs.
-[KubeAI](https://github.com/substratusai/kubeai) makes
+[KubeAI](https://github.com/kubeai-project/kubeai) makes
 it easy to deploy and manage LLMs at scale. Together, they make it easy to
 build and deploy private and secure AI applications.
 

--- a/docs/tutorials/langtrace.md
+++ b/docs/tutorials/langtrace.md
@@ -4,7 +4,7 @@ Langtrace is an open source tool that helps you with tracing and monitoring
 your AI calls. It includes a self-hosted UI that for example shows you the
 estimated costs of your LLM calls.
 
-[KubeAI](https://github.com/substratusai/kubeai) is used for deploying LLMs with an OpenAI compatible endpoint.
+[KubeAI](https://github.com/kubeai-project/kubeai) is used for deploying LLMs with an OpenAI compatible endpoint.
 
 In this tutorial you will learn how to deploy KubeAI and Langtrace end-to-end.
 Both KubeAI and Langtrace are installed in your Kubernetes cluster.

--- a/docs/tutorials/private-deep-chat.md
+++ b/docs/tutorials/private-deep-chat.md
@@ -47,7 +47,7 @@ helm install kubeai kubeai/kubeai --set open-webui.enabled=false --wait --timeou
 Clone the KubeAI repo and navigate to the example directory.
 
 ```bash
-git clone https://github.com/substratusai/kubeai
+git clone https://github.com/kubeai-project/kubeai
 cd ./kubeai/examples/private-deep-chat
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/substratusai/kubeai
+module github.com/kubeai-project/kubeai
 
 go 1.24.0
 

--- a/internal/apiutils/model_test.go
+++ b/internal/apiutils/model_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/substratusai/kubeai/internal/apiutils"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
 )
 
 func TestSplitModelAdapter(t *testing.T) {

--- a/internal/apiutils/request.go
+++ b/internal/apiutils/request.go
@@ -14,8 +14,8 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	k8sv1 "github.com/substratusai/kubeai/api/k8s/v1"
-	openaiv1 "github.com/substratusai/kubeai/api/openai/v1"
+	k8sv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	openaiv1 "github.com/kubeai-project/kubeai/api/openai/v1"
 )
 
 var (

--- a/internal/apiutils/request_test.go
+++ b/internal/apiutils/request_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 )
 
 func TestParseRequest(t *testing.T) {

--- a/internal/config/system_test.go
+++ b/internal/config/system_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/substratusai/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/config"
 )
 
 func TestAutoscalingConfig(t *testing.T) {

--- a/internal/loadbalancer/balance_chwbl.go
+++ b/internal/loadbalancer/balance_chwbl.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 
 	"github.com/cespare/xxhash"
-	"github.com/substratusai/kubeai/internal/metrics"
+	"github.com/kubeai-project/kubeai/internal/metrics"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )

--- a/internal/loadbalancer/group.go
+++ b/internal/loadbalancer/group.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/apiutils"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
 )
 
 func newEndpointGroup(lb v1.LoadBalancing) *group {

--- a/internal/loadbalancer/group_bench_test.go
+++ b/internal/loadbalancer/group_bench_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/apiutils"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
 )
 
 func BenchmarkEndpointGroup(b *testing.B) {

--- a/internal/loadbalancer/group_test.go
+++ b/internal/loadbalancer/group_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/apiutils"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
 
 	"k8s.io/apimachinery/pkg/util/rand"
 )

--- a/internal/loadbalancer/load_balancer.go
+++ b/internal/loadbalancer/load_balancer.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"sync"
 
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/apiutils"
-	"github.com/substratusai/kubeai/internal/k8sutils"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
+	"github.com/kubeai-project/kubeai/internal/k8sutils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller"

--- a/internal/loadbalancer/load_balancer_test.go
+++ b/internal/loadbalancer/load_balancer_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/apiutils"
-	"github.com/substratusai/kubeai/internal/metrics/metricstest"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
+	"github.com/kubeai-project/kubeai/internal/metrics/metricstest"
 )
 
 func TestAwaitBestHostBehavior(t *testing.T) {

--- a/internal/manager/configure.go
+++ b/internal/manager/configure.go
@@ -3,7 +3,7 @@ package manager
 import (
 	"os"
 
-	"github.com/substratusai/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/config"
 	"sigs.k8s.io/yaml"
 )
 

--- a/internal/manager/otel.go
+++ b/internal/manager/otel.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/substratusai/kubeai/internal/metrics"
+	"github.com/kubeai-project/kubeai/internal/metrics"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/propagation"

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -33,16 +33,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/leader"
-	"github.com/substratusai/kubeai/internal/loadbalancer"
-	"github.com/substratusai/kubeai/internal/messenger"
-	"github.com/substratusai/kubeai/internal/modelautoscaler"
-	"github.com/substratusai/kubeai/internal/modelclient"
-	"github.com/substratusai/kubeai/internal/modelcontroller"
-	"github.com/substratusai/kubeai/internal/modelproxy"
-	"github.com/substratusai/kubeai/internal/openaiserver"
-	"github.com/substratusai/kubeai/internal/vllmclient"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/leader"
+	"github.com/kubeai-project/kubeai/internal/loadbalancer"
+	"github.com/kubeai-project/kubeai/internal/messenger"
+	"github.com/kubeai-project/kubeai/internal/modelautoscaler"
+	"github.com/kubeai-project/kubeai/internal/modelclient"
+	"github.com/kubeai-project/kubeai/internal/modelcontroller"
+	"github.com/kubeai-project/kubeai/internal/modelproxy"
+	"github.com/kubeai-project/kubeai/internal/openaiserver"
+	"github.com/kubeai-project/kubeai/internal/vllmclient"
 
 	// Pulling in these packages will register the gocloud implementations.
 	_ "gocloud.dev/pubsub/awssnssqs"
@@ -54,7 +54,7 @@ import (
 
 	// +kubebuilder:scaffold:imports
 
-	"github.com/substratusai/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/config"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 

--- a/internal/messenger/messenger.go
+++ b/internal/messenger/messenger.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 	"time"
 
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/apiutils"
-	"github.com/substratusai/kubeai/internal/metrics"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
+	"github.com/kubeai-project/kubeai/internal/metrics"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"gocloud.dev/pubsub"

--- a/internal/metrics/metricstest/metricstest.go
+++ b/internal/metrics/metricstest/metricstest.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/substratusai/kubeai/internal/metrics"
+	"github.com/kubeai-project/kubeai/internal/metrics"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"

--- a/internal/modelautoscaler/autoscaler.go
+++ b/internal/modelautoscaler/autoscaler.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/substratusai/kubeai/internal/config"
-	"github.com/substratusai/kubeai/internal/leader"
-	"github.com/substratusai/kubeai/internal/loadbalancer"
-	"github.com/substratusai/kubeai/internal/modelclient"
-	"github.com/substratusai/kubeai/internal/movingaverage"
+	"github.com/kubeai-project/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/leader"
+	"github.com/kubeai-project/kubeai/internal/loadbalancer"
+	"github.com/kubeai-project/kubeai/internal/modelclient"
+	"github.com/kubeai-project/kubeai/internal/movingaverage"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/internal/modelautoscaler/metrics.go
+++ b/internal/modelautoscaler/metrics.go
@@ -9,7 +9,7 @@ import (
 
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
-	"github.com/substratusai/kubeai/internal/metrics"
+	"github.com/kubeai-project/kubeai/internal/metrics"
 )
 
 func aggregateAllMetrics(agg *metricsAggregation, addrs []string, path string) (err error) {

--- a/internal/modelclient/client.go
+++ b/internal/modelclient/client.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/modelclient/scale.go
+++ b/internal/modelclient/scale.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/modelcontroller/adapters.go
+++ b/internal/modelcontroller/adapters.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"strings"
 
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/k8sutils"
-	"github.com/substratusai/kubeai/internal/vllmclient"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/k8sutils"
+	"github.com/kubeai-project/kubeai/internal/vllmclient"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/internal/modelcontroller/cache.go
+++ b/internal/modelcontroller/cache.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/k8sutils"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/k8sutils"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/modelcontroller/engine_fasterwhisper.go
+++ b/internal/modelcontroller/engine_fasterwhisper.go
@@ -3,7 +3,7 @@ package modelcontroller
 import (
 	"sort"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/internal/modelcontroller/engine_infinity.go
+++ b/internal/modelcontroller/engine_infinity.go
@@ -3,7 +3,7 @@ package modelcontroller
 import (
 	"sort"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/internal/modelcontroller/engine_ollama.go
+++ b/internal/modelcontroller/engine_ollama.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/internal/modelcontroller/engine_ollama_test.go
+++ b/internal/modelcontroller/engine_ollama_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/modelcontroller/engine_vllm.go
+++ b/internal/modelcontroller/engine_vllm.go
@@ -3,7 +3,7 @@ package modelcontroller
 import (
 	"sort"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/internal/modelcontroller/files.go
+++ b/internal/modelcontroller/files.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/modelcontroller/files_test.go
+++ b/internal/modelcontroller/files_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -35,10 +35,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/config"
-	"github.com/substratusai/kubeai/internal/k8sutils"
-	"github.com/substratusai/kubeai/internal/vllmclient"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/k8sutils"
+	"github.com/kubeai-project/kubeai/internal/vllmclient"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/internal/modelcontroller/model_controller_test.go
+++ b/internal/modelcontroller/model_controller_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/config"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )

--- a/internal/modelcontroller/model_source.go
+++ b/internal/modelcontroller/model_source.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )

--- a/internal/modelcontroller/patch.go
+++ b/internal/modelcontroller/patch.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/substratusai/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/config"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 	corev1 "k8s.io/api/core/v1"
 )

--- a/internal/modelcontroller/patch_test.go
+++ b/internal/modelcontroller/patch_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/substratusai/kubeai/internal/config"
-	"github.com/substratusai/kubeai/internal/k8sutils"
+	"github.com/kubeai-project/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/k8sutils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"

--- a/internal/modelcontroller/pod_plan.go
+++ b/internal/modelcontroller/pod_plan.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/k8sutils"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/k8sutils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/modelcontroller/pod_plan_test.go
+++ b/internal/modelcontroller/pod_plan_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/config"
-	"github.com/substratusai/kubeai/internal/k8sutils"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/k8sutils"
 	"golang.org/x/exp/rand"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/internal/modelproxy/handler.go
+++ b/internal/modelproxy/handler.go
@@ -8,9 +8,9 @@ import (
 	"net/http/httputil"
 	"net/url"
 
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/apiutils"
-	"github.com/substratusai/kubeai/internal/metrics"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
+	"github.com/kubeai-project/kubeai/internal/metrics"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )

--- a/internal/modelproxy/handler_test.go
+++ b/internal/modelproxy/handler_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/apiutils"
-	"github.com/substratusai/kubeai/internal/metrics/metricstest"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
+	"github.com/kubeai-project/kubeai/internal/metrics/metricstest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/modelproxy/request.go
+++ b/internal/modelproxy/request.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/substratusai/kubeai/internal/apiutils"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
 )
 
 // proxyRequest keeps track of the state of a request that is to be proxied.

--- a/internal/movingaverage/simple_test.go
+++ b/internal/movingaverage/simple_test.go
@@ -3,7 +3,7 @@ package movingaverage_test
 import (
 	"testing"
 
-	"github.com/substratusai/kubeai/internal/movingaverage"
+	"github.com/kubeai-project/kubeai/internal/movingaverage"
 )
 
 func TestSimple(t *testing.T) {

--- a/internal/openaiserver/handler.go
+++ b/internal/openaiserver/handler.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/substratusai/kubeai/internal/modelproxy"
+	"github.com/kubeai-project/kubeai/internal/modelproxy"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/internal/openaiserver/models.go
+++ b/internal/openaiserver/models.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/apiutils"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: KubeAI
 site_url: https://www.kubeai.org
-repo_url: https://github.com/substratusai/kubeai
+repo_url: https://github.com/kubeai-project/kubeai
 
 theme:
   name: material

--- a/test/integration/adapter_test.go
+++ b/test/integration/adapter_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/apiutils"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/apiutils"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/test/integration/autoscaler_state_test.go
+++ b/test/integration/autoscaler_state_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/substratusai/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"

--- a/test/integration/autoscaling_ha_test.go
+++ b/test/integration/autoscaling_ha_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/substratusai/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/config"
 	"k8s.io/utils/ptr"
 )
 

--- a/test/integration/cache_shared_filesystem_test.go
+++ b/test/integration/cache_shared_filesystem_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/config"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/config"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/substratusai/kubeai/internal/config"
-	"github.com/substratusai/kubeai/internal/manager"
+	"github.com/kubeai-project/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/manager"
 	"gocloud.dev/pubsub"
 	_ "gocloud.dev/pubsub/mempubsub"
 	corev1 "k8s.io/api/core/v1"

--- a/test/integration/messenger_test.go
+++ b/test/integration/messenger_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/substratusai/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/config"
 	"gocloud.dev/pubsub"
 )
 

--- a/test/integration/model_files_test.go
+++ b/test/integration/model_files_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	kubeaiv1 "github.com/substratusai/kubeai/api/k8s/v1"
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/test/integration/model_pod_update_rollout_test.go
+++ b/test/integration/model_pod_update_rollout_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/substratusai/kubeai/internal/k8sutils"
+	"github.com/kubeai-project/kubeai/internal/k8sutils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/test/integration/model_validation_test.go
+++ b/test/integration/model_validation_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )

--- a/test/integration/proxy_test.go
+++ b/test/integration/proxy_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/substratusai/kubeai/internal/config"
+	"github.com/kubeai-project/kubeai/internal/config"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "github.com/substratusai/kubeai/api/k8s/v1"
-	"github.com/substratusai/kubeai/internal/openaiserver"
+	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/openaiserver"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
## Summary
- update the Go module path and imports to github.com/kubeai-project/kubeai
- refresh documentation and configuration references to the new repository URL

## Testing
- go test ./... *(fails to complete; interrupted due to hanging)*

------
https://chatgpt.com/codex/tasks/task_e_68e65c13aca8832e90a1b0e885f08a6a