### PR TITLE
Allow configuring cache PVC storage per model

### DIFF
--- a/api/k8s/v1/model_types.go
+++ b/api/k8s/v1/model_types.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -75,6 +76,11 @@ type ModelSpec struct {
 	// Must be a valid CacheProfile defined in the system config.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="cacheProfile is immutable."
 	CacheProfile string `json:"cacheProfile,omitempty"`
+
+	// CacheStorage defines the requested storage size for the cache PersistentVolumeClaim
+	// when using a cacheProfile backed by a shared filesystem.
+	// +kubebuilder:validation:Optional
+	CacheStorage *resource.Quantity `json:"cacheStorage,omitempty"`
 
 	// Image to be used for the server process.
 	// Will be set from ResourceProfile + Engine if not specified.

--- a/api/k8s/v1/zz_generated.deepcopy.go
+++ b/api/k8s/v1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -187,6 +188,11 @@ func (in *ModelSpec) DeepCopyInto(out *ModelSpec) {
 		in, out := &in.Files, &out.Files
 		*out = make([]File, len(*in))
 		copy(*out, *in)
+	}
+	if in.CacheStorage != nil {
+		in, out := &in.CacheStorage, &out.CacheStorage
+		*out = new(resource.Quantity)
+		**out = **in
 	}
 }
 

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -78,6 +78,11 @@ spec:
                 x-kubernetes-validations:
                 - message: cacheProfile is immutable.
                   rule: self == oldSelf
+              cacheStorage:
+                description: |-
+                  Requested storage size for the cache PersistentVolumeClaim when using a
+                  shared filesystem cache profile. Defaults to 10Gi if omitted.
+                type: string
               engine:
                 description: Engine to be used for the server process.
                 enum:

--- a/docs/reference/kubernetes-api.md
+++ b/docs/reference/kubernetes-api.md
@@ -134,6 +134,7 @@ _Appears in:_
 | `engine` _string_ | Engine to be used for the server process. |  | Enum: [OLlama VLLM FasterWhisper Infinity] <br />Required: \{\} <br /> |
 | `resourceProfile` _string_ | ResourceProfile required to serve the model.<br />Use the format "<resource-profile-name>:<count>".<br />Example: "nvidia-gpu-l4:2" - 2x NVIDIA L4 GPUs.<br />Must be a valid ResourceProfile defined in the system config. |  |  |
 | `cacheProfile` _string_ | CacheProfile to be used for caching model artifacts.<br />Must be a valid CacheProfile defined in the system config. |  |  |
+| `cacheStorage` _string_ | Requested storage size for the cache PersistentVolumeClaim when using a shared filesystem cache profile.<br />Defaults to `10Gi` if omitted. |  |  |
 | `image` _string_ | Image to be used for the server process.<br />Will be set from ResourceProfile + Engine if not specified. |  |  |
 | `args` _string array_ | Args to be added to the server process. |  |  |
 | `env` _object (keys:string, values:string)_ | Env variables to be added to the server process. |  |  |

--- a/internal/modelcontroller/cache.go
+++ b/internal/modelcontroller/cache.go
@@ -286,9 +286,13 @@ func (r *ModelReconciler) cachePVCForModel(m *kubeaiv1.Model, c ModelConfig) *co
 		storageClassName := c.CacheProfile.SharedFilesystem.StorageClassName
 		pvc.Spec.StorageClassName = &storageClassName
 		pvc.Spec.VolumeName = c.CacheProfile.SharedFilesystem.PersistentVolumeName
+		storageRequest := resource.MustParse("10Gi")
+		if m.Spec.CacheStorage != nil {
+			storageRequest = *m.Spec.CacheStorage
+		}
 		pvc.Spec.Resources.Requests = corev1.ResourceList{
 			// https://discuss.huggingface.co/t/how-to-get-model-size/11038/7
-			corev1.ResourceStorage: resource.MustParse("10Gi"),
+			corev1.ResourceStorage: storageRequest,
 		}
 	default:
 		panic("unsupported cache profile, this point should not be reached")

--- a/manifests/crds/kubeai.org_models.yaml
+++ b/manifests/crds/kubeai.org_models.yaml
@@ -77,6 +77,11 @@ spec:
                 x-kubernetes-validations:
                 - message: cacheProfile is immutable.
                   rule: self == oldSelf
+              cacheStorage:
+                description: |-
+                  Requested storage size for the cache PersistentVolumeClaim when using a
+                  shared filesystem cache profile. Defaults to 10Gi if omitted.
+                type: string
               engine:
                 description: Engine to be used for the server process.
                 enum:

--- a/test/integration/cache_shared_filesystem_test.go
+++ b/test/integration/cache_shared_filesystem_test.go
@@ -12,6 +12,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +38,8 @@ func TestCacheSharedFilesystem(t *testing.T) {
 	m := modelForTest(t)
 	m.Spec.MinReplicas = 1
 	m.Spec.CacheProfile = cacheProfileName
+cacheStorage := resource.MustParse("2Gi")
+	m.Spec.CacheStorage = &cacheStorage
 	require.NoError(t, testK8sClient.Create(testCtx, m))
 
 	// Assert that the expected PVC is created
@@ -49,6 +52,7 @@ func TestCacheSharedFilesystem(t *testing.T) {
 	}, 15*time.Second, time.Second/10, "PVC should be created")
 	require.Equal(t, ptr.To("my-storage-class"), pvc.Spec.StorageClassName)
 	require.Equal(t, "my-pv", pvc.Spec.VolumeName)
+require.Equal(t, resource.MustParse("2Gi"), pvc.Spec.Resources.Requests[corev1.ResourceStorage])
 
 	// Assert that the model loader Job is created
 	loaderJob := &batchv1.Job{}


### PR DESCRIPTION
## Summary
- add an optional `cacheStorage` field to Model specs and propagate it to generated CRDs
- request cache PVC capacity from the model spec instead of a fixed 10Gi default
- document the new field and cover it with integration test expectations, ensuring the shared cache test requests the 2Gi size defined in the model manifest

## Testing
- not run (integration suite requires a full Kubernetes test environment)